### PR TITLE
Add support for webjars-locator.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
             <version>3.1.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.webjars.bower</groupId>
+            <artifactId>js-base64</artifactId>
+            <version>2.3.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -26,6 +26,8 @@ public class WebJarVersionLocator {
     private static final String PLAIN = "org.webjars/";
     private static final String POM_PROPERTIES = "/pom.properties";
 
+    private static final String CACHE_KEY_PREFIX = "version-";
+
     private static final ClassLoader LOADER = WebJarVersionLocator.class.getClassLoader();
 
     private final WebJarCache cache;
@@ -83,7 +85,7 @@ public class WebJarVersionLocator {
      */
     @Nullable
     public String version(final String webJarName) {
-        final String cacheKey = "version-" + webJarName;
+        final String cacheKey = CACHE_KEY_PREFIX + webJarName;
         final Optional<String> optionalVersion = cache.computeIfAbsent(cacheKey, (key) -> {
             InputStream resource = LOADER.getResourceAsStream(PROPERTIES_ROOT + NPM + webJarName + POM_PROPERTIES);
             if (resource == null) {

--- a/src/main/resources/META-INF/native-image/org.webjars/webjars-locator-lite/resource-config.json
+++ b/src/main/resources/META-INF/native-image/org.webjars/webjars-locator-lite/resource-config.json
@@ -1,0 +1,30 @@
+{
+    "resources": {
+        "includes": [
+            {
+                "pattern": "\\QMETA-INF/resources/webjars-locator.properties\\E",
+                "condition": {
+                    "typeReachable": "org.webjars.WebJarVersionLocator"
+                }
+            },
+            {
+                "pattern": "\\QMETA-INF\/resources\/webjars\/\\E.*",
+                "condition": {
+                    "typeReachable": "org.webjars.WebJarVersionLocator"
+                }
+            },
+            {
+                "pattern": "\\QMETA-INF/maven/org.webjars/\\E.*\\Q/pom.properties\\E",
+                "condition": {
+                    "typeReachable": "org.webjars.WebJarVersionLocator"
+                }
+            },
+            {
+                "pattern": "\\QMETA-INF/maven/org.webjars.npm/\\E.*\\Q/pom.properties\\E",
+                "condition": {
+                    "typeReachable": "org.webjars.WebJarVersionLocator"
+                }
+            }
+        ]
+    }
+}

--- a/src/test/java/org/webjars/WebJarVersionLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarVersionLocatorTest.java
@@ -24,6 +24,21 @@ class WebJarVersionLocatorTest {
     }
 
     @Test
+    void should_find_good_custom_webjar_version() {
+        assertEquals("3.2.1", new WebJarVersionLocator().version("goodwebjar"));
+    }
+
+    @Test
+    void should_not_find_bad_custom_webjar_version() {
+        assertNull(new WebJarVersionLocator().version("badwebjar"));
+    }
+
+    @Test
+    void should_find_bower_webjar_version() {
+        assertEquals("2.3.2", new WebJarVersionLocator().version("js-base64"));
+    }
+
+    @Test
     void webjar_version_doesnt_match_path() {
         assertEquals("3.1.1", new WebJarVersionLocator().version("bootstrap"));
     }

--- a/src/test/java/org/webjars/WebJarVersionLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarVersionLocatorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -60,6 +61,7 @@ class WebJarVersionLocatorTest {
 
     @Test
     void cache_is_populated_on_lookup() {
+        AtomicBoolean shouldInspect = new AtomicBoolean(false);
         AtomicInteger numLookups = new AtomicInteger(0);
 
         @NullMarked
@@ -69,7 +71,9 @@ class WebJarVersionLocatorTest {
             @Override
             public Optional<String> computeIfAbsent(String key, Function<String, Optional<String>> function) {
                 Function<String, Optional<String>> inspectableFunction = function.andThen((value) -> {
-                    numLookups.incrementAndGet();
+                    if(shouldInspect.get()) {
+                        numLookups.incrementAndGet();
+                    }
                     return value;
                 });
                 return cache.computeIfAbsent(key, inspectableFunction);
@@ -77,6 +81,8 @@ class WebJarVersionLocatorTest {
         }
 
         final WebJarVersionLocator webJarVersionLocator = new WebJarVersionLocator(new InspectableCache());
+        // enable inspection after webJarVersionLocator has been constructed, to ignore lookups caused by loading webjars-locator.properties
+        shouldInspect.set(true);
 
         assertEquals("3.1.1", webJarVersionLocator.version("bootstrap"));
         assertEquals(1, numLookups.get());

--- a/src/test/resources/META-INF/resources/webjars-locator.properties
+++ b/src/test/resources/META-INF/resources/webjars-locator.properties
@@ -1,0 +1,8 @@
+# WebJar that can be found on classpath
+goodwebjar.version=3.2.1
+
+# WebJar that is not present in classpath
+badwebjar.version=1.2.3
+
+# Bower Webjar from dependencies
+js-base64.version=2.3.2

--- a/src/test/resources/META-INF/resources/webjars/goodwebjar/3.2.1/goodwebjar.js
+++ b/src/test/resources/META-INF/resources/webjars/goodwebjar/3.2.1/goodwebjar.js
@@ -1,0 +1,1 @@
+// Awesome WebJar content


### PR DESCRIPTION
With this PR I want to bring up a possible implementation for supporting legacy and custom webjars with webjars-locator-lite. I started the related discussion in https://github.com/webjars/webjars-locator-lite/issues/13.

Unfortunately there was no decision on how to implement this feature in the related issue, therefore I tried to come up with something based on the suggestions.

The Implementation provided by this PR looks for `META-INF/webjars/locator.properties` files on the classpath and then reads them into a `Properties` instance. I decided to use a pattern of `WEBJAR_NAME.version` as key in the properties file to have the option to add other properties in the future (and be more specific about the purpose of the property -> providing a version). The value for each key has to be the version of the webjar as used in the resulting path.

When reading the `locator.properties` the `.version` suffix is removed and the given version is put into the cache. Before adding a given webjar version to the cache, it checks if the resulting path exists.

The files are loaded in whatever order `LOADER.getResources()` returns them.

With this change, it is possible to support any legacy (e.g. bower) or custom webjar, as long as the basic path structure is valid (`META-INF/resources/webjars/WEBJAR/VERSION/any/folder/or.file`)