### PR TITLE
Add info about webjars-locator.properties to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ webJarVersionLocator.version("bootstrap"); // cache miss
 webJarVersionLocator.version("bootstrap"); // cache hit, avoiding looking up metadata in the classpath
 ```
 
-Custom Webjars
+Custom WebJars
 --------------------------------
 
 By default, `webjars-locator-lite` only supports WebJars with the Maven group IDs of `org.webjars` and `org.webjars.npm`.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,32 @@ WebJarVersionLocator webJarVersionLocator = new WebJarVersionLocator();
 webJarVersionLocator.version("bootstrap"); // cache miss
 webJarVersionLocator.version("bootstrap"); // cache hit, avoiding looking up metadata in the classpath
 ```
+
+Custom Webjars
+--------------------------------
+
+By default, `webjars-locator-lite` only supports WebJars with the Maven group IDs of `org.webjars` and `org.webjars.npm`.
+To support custom WebJars, you can provide a `webjars-locator.properties` file to register those WebJars with the locator.
+
+The `webjars-locator.properties` file must be located in `META-INF/resources/`.
+
+For a WebJar that has its resource files located in `META-INF/resources/mywebjar/3.2.1/`, the file would look like this:
+
+```
+mywebjar.version=3.2.1
+```
+
+For custom WebJars, it is recommended to package the file within the WebJar.  
+However, for older releases that do not include this file, it is also possible to add it to your project directly.  
+
+Multiple WebJar versions can be defined in a single file:
+
+```
+mywebjar.version=3.2.1
+anotherwebjar.version=1.4.3
+```
+
+> This allows the use of [legacy](https://github.com/webjars/webjars/issues/2039) `org.webjars.bower` WebJars. However, `org.webjars.bowergithub.xyz` WebJars are not supported because their
+> resource paths are missing the version part needed for `webjars-locator-lite`.
+
+You can find an [example file](https://github.com/webjars/webjars-locator-lite/blob/main/src/test/resources/META-INF/resources/webjars-locator.properties) in our tests.


### PR DESCRIPTION
This PR adds a bit of documentation regarding the `webjars-locator.properties` file added in https://github.com/webjars/webjars-locator-lite/pull/15

I was not sure about adding the note about Bower WebJars, but decided to add it for now.

related issue: https://github.com/webjars/webjars-locator-lite/issues/13
