### PR TITLE
Ensure consistent behaviour for path and fullPath

### DIFF
--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -14,7 +14,28 @@ import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
- * Locate WebJar version. The class is thread safe.
+ * Helper Class to locate WebJar versions.
+ *
+ * <p>By default, this class only supports looking up official WebJars with the Maven group IDs of {@code org.webjars.npm} and {@code org.webjars}.
+ *
+ * <p>Custom WenJars can be registered by providing a {@code META-INF/resources/webjars-locator.properties} file.
+ *
+ * <p><b>Note:</b> It is recommended, to add this file directly to the custom WebJar to ease the usage.
+ * But for WebJars not providing the file, you can add a {@code webjars-locator.properties} to your project.
+ *
+ * <p>Example file (multiple WebJars can be provided, one per line):
+ * <pre>{@code
+ * mywebjar.version=3.2.1
+ * anotherwebjar.version=1.4.3
+ * }</pre>
+ *
+ * <p>As the lookup of all {@code webjars-locator.properties} files happens during the construction of the class
+ * and the found versions are directly added to the cache, these property files can and will override versions
+ * that otherwise would be looked up by {@link WebJarVersionLocator#version(String)}.
+ *
+ * <p>When multiple {@code webjars-locator.properties} files contain a version for the same WebJar, the one that has been found first wins.
+ *
+ * <p>The class is thread safe.
  */
 @NullMarked
 public class WebJarVersionLocator {
@@ -47,13 +68,23 @@ public class WebJarVersionLocator {
     }
 
     /**
-     * @param webJarName The name of the WebJar, i.e. bootstrap
-     * @param exactPath The path to the file within the WebJar, i.e. js/bootstrap.js
-     * @return The full path to the file in the classpath including the version, i.e. META-INF/resources/webjars/bootstrap/3.1.1/js/bootstrap.js
+     * Builds the versioned path for a file of a WebJar within the standard WebJar classpath location (see {@link WebJarVersionLocator#WEBJARS_PATH_PREFIX}).
+     *
+     * <p>The path is build by prefixing the versioned path built by {@link WebJarVersionLocator#path(String, String)} with the standard WebJars location classpath.
+     *
+     * <p>See {@link WebJarVersionLocator#path(String, String)} for a detailed explanation of how the versioned file path is built.
+     *
+     * <p><b>Note:</b> This method does not perform any checks if the resulting path references an existing file.
+     *
+     * @param webJarName The name of the WebJar
+     * @param filePath   The path to the file within the WebJar
+     * @return The versioned path to the file in the classpath; null if no version for {@code webJarName} is known
+     * @see WebJarVersionLocator#path(String, String)
+     * @see WebJarVersionLocator#WEBJARS_PATH_PREFIX
      */
     @Nullable
-    public String fullPath(final String webJarName, final String exactPath) {
-        final String path = path(webJarName, exactPath);
+    public String fullPath(final String webJarName, final String filePath) {
+        final String path = path(webJarName, filePath);
 
         if (notEmpty(path)) {
             return String.format("%s/%s", WEBJARS_PATH_PREFIX, path);
@@ -63,20 +94,43 @@ public class WebJarVersionLocator {
     }
 
     /**
+     * Builds the versioned path for a file of a WebJar relative to the standard WebJar classpath location (see {@link WebJarVersionLocator#WEBJARS_PATH_PREFIX}).
      *
-     * @param webJarName The name of the WebJar, i.e. bootstrap
-     * @param exactPath The path to the file within the WebJar, i.e. js/bootstrap.js
-     * @return The path to the file in the standard WebJar classpath location, including the version, i.e. bootstrap/3.1.1/js/bootstrap.js
+     * <p>The path is built by joining the {@code webJarName}, the known version and the {@code filePath}, if no version is known for the WebJar this method returns {@code null}.
+     *
+     * <p><b>Note:</b> In cases where the {@code filePath} parameter already starts with the known version of the WebJar, the version will not be added again.
+     *
+     * <pre>{@code
+     * // returns "bootstrap/3.1.1/js/bootstrap.js"
+     * locator.path("bootstrap", "css/bootstrap.css");
+     *
+     * // returns "bootstrap/3.1.1/js/bootstrap.js" as well
+     * locator.path("bootstrap", "3.1.1/css/bootstrap.css");
+     *
+     * // returns null, assuming there is no "unknown" WebJar
+     * locator.path("unknown", "some/file.css");
+     * }</pre>
+     *
+     * <p><b>Note:</b> When the {@code filePath} starts with a version, that is not the correct version of the WebJar, this method returns a path with both versions.
+     * <br>For example {@code bootstrap/5.3.3/3.1.1/css/boostrap.css}.
+     *
+     * <p><b>Note:</b> This method does not perform any checks if the resulting path references an existing file.
+     *
+     * @param webJarName The name of the WebJar
+     * @param filePath   The path to the file within the WebJar
+     * @return The versioned path relative to the standard WebJar classpath location; null if no version for {@code webJarName} is known
+     * @see WebJarVersionLocator#fullPath(String, String)
+     * @see WebJarVersionLocator#WEBJARS_PATH_PREFIX
      */
     @Nullable
-    public String path(final String webJarName, final String exactPath) {
+    public String path(final String webJarName, final String filePath) {
         final String version = version(webJarName);
 
         if (notEmpty(version)) {
-            if (exactPath.startsWith(version)) {
-                return String.format("%s/%s", webJarName, exactPath);
+            if (filePath.startsWith(version)) {
+                return String.format("%s/%s", webJarName, filePath);
             } else {
-                return String.format("%s/%s/%s", webJarName, version, exactPath);
+                return String.format("%s/%s/%s", webJarName, version, filePath);
             }
         }
 
@@ -84,8 +138,16 @@ public class WebJarVersionLocator {
     }
 
     /**
-     * @param webJarName The name of the WebJar, i.e. bootstrap
-     * @return The version of the WebJar, i.e 3.1.1
+     * This method tries to determine the available version for a WebJar in the classpath.
+     *
+     * <p>For official WebJars, the version lookup is performed by checking for a {@code pom.properties} file for either {@link WebJarVersionLocator#NPM}
+     * or {@link WebJarVersionLocator#PLAIN} WebJars within {@code META-INF/maven}. The lookup result is cached.
+     *
+     * <p>Custom WebJars can be registered by using a {@code webjars-locator.properties} file. See {@link WebJarVersionLocator} for details.
+     *
+     * @param webJarName The name of the WebJar
+     * @return The version of the WebJar; or null if no version is found
+     * @see WebJarVersionLocator
      */
     @Nullable
     public String version(final String webJarName) {

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -73,7 +73,11 @@ public class WebJarVersionLocator {
         final String version = version(webJarName);
 
         if (!isEmpty(version)) {
-            return String.format("%s/%s/%s", webJarName, version, exactPath);
+            if (exactPath.startsWith(version)) {
+                return String.format("%s/%s", webJarName, exactPath);
+            } else {
+                return String.format("%s/%s/%s", webJarName, version, exactPath);
+            }
         }
 
         return null;

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -96,7 +96,7 @@ public class WebJarVersionLocator {
     /**
      * Builds the versioned path for a file of a WebJar relative to the standard WebJar classpath location (see {@link WebJarVersionLocator#WEBJARS_PATH_PREFIX}).
      *
-     * <p>The path is built by joining the {@code webJarName}, the known version and the {@code filePath}, if no version is known for the WebJar this method returns {@code null}.
+     * <p>The path is built by joining the {@code webJarName}, the known version and the {@code filePath}, if no version (from classpath checking) is known for the WebJar this method returns {@code null}.
      *
      * <p><b>Note:</b> In cases where the {@code filePath} parameter already starts with the known version of the WebJar, the version will not be added again.
      *

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -111,9 +111,6 @@ public class WebJarVersionLocator {
      * locator.path("unknown", "some/file.css");
      * }</pre>
      *
-     * <p><b>Note:</b> When the {@code filePath} starts with a version, that is not the correct version of the WebJar, this method returns a path with both versions.
-     * <br>For example {@code bootstrap/5.3.3/3.1.1/css/boostrap.css}.
-     *
      * <p><b>Note:</b> This method does not perform any checks if the resulting path references an existing file.
      *
      * @param webJarName The name of the WebJar

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -76,9 +76,9 @@ public class WebJarVersionLocator {
      *
      * <p><b>Note:</b> This method does not perform any checks if the resulting path references an existing file.
      *
-     * @param webJarName The name of the WebJar
+     * @param webJarName The name of the WebJar, this is the directory in the standard WebJar classpath location, usually the same as the Maven artifact ID
      * @param filePath   The path to the file within the WebJar
-     * @return The versioned path to the file in the classpath; null if no version for {@code webJarName} is known
+     * @return The versioned path to the file in the classpath, if a version has been found, otherwise {@code null}
      * @see WebJarVersionLocator#path(String, String)
      * @see WebJarVersionLocator#WEBJARS_PATH_PREFIX
      */
@@ -113,9 +113,9 @@ public class WebJarVersionLocator {
      *
      * <p><b>Note:</b> This method does not perform any checks if the resulting path references an existing file.
      *
-     * @param webJarName The name of the WebJar
+     * @param webJarName The name of the WebJar, this is the directory in the standard WebJar classpath location, usually the same as the Maven artifact ID
      * @param filePath   The path to the file within the WebJar
-     * @return The versioned path relative to the standard WebJar classpath location; null if no version for {@code webJarName} is known
+     * @return The versioned path relative to the standard WebJar classpath location, if a version has been found, otherwise {@code null}
      * @see WebJarVersionLocator#fullPath(String, String)
      * @see WebJarVersionLocator#WEBJARS_PATH_PREFIX
      */
@@ -142,8 +142,8 @@ public class WebJarVersionLocator {
      *
      * <p>Custom WebJars can be registered by using a {@code webjars-locator.properties} file. See {@link WebJarVersionLocator} for details.
      *
-     * @param webJarName The name of the WebJar (the Maven artifact ID)
-     * @return The version of the WebJar; or null if no version is found
+     * @param webJarName The name of the WebJar, this is the directory in the standard WebJar classpath location, usually the same as the Maven artifact ID
+     * @return The version of the WebJar, if found, otherwise {@code null}
      * @see WebJarVersionLocator
      */
     @Nullable

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -53,16 +53,10 @@ public class WebJarVersionLocator {
      */
     @Nullable
     public String fullPath(final String webJarName, final String exactPath) {
-        final String version = version(webJarName);
+        final String path = path(webJarName, exactPath);
 
-        if (!isEmpty(version)) {
-            // todo: not sure why we check this
-            if (!exactPath.startsWith(version)) {
-                 return String.format("%s/%s/%s/%s", WEBJARS_PATH_PREFIX, webJarName, version, exactPath);
-            }
-            else {
-                return String.format("%s/%s/%s", WEBJARS_PATH_PREFIX, webJarName, exactPath);
-            }
+        if (!isEmpty(path)) {
+            return String.format("%s/%s", WEBJARS_PATH_PREFIX, path);
         }
 
         return null;

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -145,7 +145,7 @@ public class WebJarVersionLocator {
      *
      * <p>Custom WebJars can be registered by using a {@code webjars-locator.properties} file. See {@link WebJarVersionLocator} for details.
      *
-     * @param webJarName The name of the WebJar
+     * @param webJarName The name of the WebJar (the Maven artifact ID)
      * @return The version of the WebJar; or null if no version is found
      * @see WebJarVersionLocator
      */

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -98,7 +98,7 @@ public class WebJarVersionLocator {
      *
      * <p>The path is built by joining the {@code webJarName}, the known version and the {@code filePath}, if no version (from classpath checking) is known for the WebJar this method returns {@code null}.
      *
-     * <p><b>Note:</b> In cases where the {@code filePath} parameter already starts with the known version of the WebJar, the version will not be added again.
+     * <p><b>Note:</b> In cases where the {@code filePath} parameter already starts with the known version of the WebJar, the version will not be added again. But it is recommended that you do NOT include a hard-coded version when looking up WebJar file paths.
      *
      * <pre>{@code
      * // returns "bootstrap/3.1.1/js/bootstrap.js"

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -70,7 +70,7 @@ public class WebJarVersionLocator {
     /**
      * Builds the versioned path for a file of a WebJar within the standard WebJar classpath location (see {@link WebJarVersionLocator#WEBJARS_PATH_PREFIX}).
      *
-     * <p>The path is build by prefixing the versioned path built by {@link WebJarVersionLocator#path(String, String)} with the standard WebJars location classpath.
+     * <p>The path is built by prefixing the versioned path built by {@link WebJarVersionLocator#path(String, String)} with the standard WebJars location classpath.
      *
      * <p>See {@link WebJarVersionLocator#path(String, String)} for a detailed explanation of how the versioned file path is built.
      *

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -55,7 +55,7 @@ public class WebJarVersionLocator {
     public String fullPath(final String webJarName, final String exactPath) {
         final String path = path(webJarName, exactPath);
 
-        if (!isEmpty(path)) {
+        if (notEmpty(path)) {
             return String.format("%s/%s", WEBJARS_PATH_PREFIX, path);
         }
 
@@ -72,7 +72,7 @@ public class WebJarVersionLocator {
     public String path(final String webJarName, final String exactPath) {
         final String version = version(webJarName);
 
-        if (!isEmpty(version)) {
+        if (notEmpty(version)) {
             if (exactPath.startsWith(version)) {
                 return String.format("%s/%s", webJarName, exactPath);
             } else {
@@ -166,8 +166,8 @@ public class WebJarVersionLocator {
         return LOADER.getResource(WEBJARS_PATH_PREFIX + "/" + webJarName + "/" + path) != null;
     }
 
-    private boolean isEmpty(@Nullable final String str) {
-        return str == null || str.trim().isEmpty();
+    private boolean notEmpty(@Nullable final String str) {
+        return str != null && !str.trim().isEmpty();
     }
 
 }

--- a/src/main/java/org/webjars/WebJarVersionLocator.java
+++ b/src/main/java/org/webjars/WebJarVersionLocator.java
@@ -101,10 +101,10 @@ public class WebJarVersionLocator {
      * <p><b>Note:</b> In cases where the {@code filePath} parameter already starts with the known version of the WebJar, the version will not be added again. But it is recommended that you do NOT include a hard-coded version when looking up WebJar file paths.
      *
      * <pre>{@code
-     * // returns "bootstrap/3.1.1/js/bootstrap.js"
+     * // returns "bootstrap/3.1.1/css/bootstrap.css"
      * locator.path("bootstrap", "css/bootstrap.css");
      *
-     * // returns "bootstrap/3.1.1/js/bootstrap.js" as well
+     * // returns "bootstrap/3.1.1/css/bootstrap.css" as well
      * locator.path("bootstrap", "3.1.1/css/bootstrap.css");
      *
      * // returns null, assuming there is no "unknown" WebJar

--- a/src/test/java/org/webjars/WebJarVersionLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarVersionLocatorTest.java
@@ -55,8 +55,13 @@ class WebJarVersionLocatorTest {
     }
 
     @Test
-    void full_path_exists_version_supplied() {
-        assertEquals(WebJarVersionLocator.WEBJARS_PATH_PREFIX + "/bootstrap/3.1.1/js/bootstrap.js", new WebJarVersionLocator().fullPath("bootstrap", "3.1.1/js/bootstrap.js"));
+    void full_path_double_version_with_version_supplied() {
+        assertEquals(WebJarVersionLocator.WEBJARS_PATH_PREFIX + "/bootstrap/3.1.1/3.1.1/js/bootstrap.js", new WebJarVersionLocator().fullPath("bootstrap", "3.1.1/js/bootstrap.js"));
+    }
+
+    @Test
+    void path_double_version_with_version_supplied() {
+        assertEquals("bootstrap/3.1.1/3.1.1/js/bootstrap.js", new WebJarVersionLocator().path("bootstrap", "3.1.1/js/bootstrap.js"));
     }
 
     @Test

--- a/src/test/java/org/webjars/WebJarVersionLocatorTest.java
+++ b/src/test/java/org/webjars/WebJarVersionLocatorTest.java
@@ -55,13 +55,13 @@ class WebJarVersionLocatorTest {
     }
 
     @Test
-    void full_path_double_version_with_version_supplied() {
-        assertEquals(WebJarVersionLocator.WEBJARS_PATH_PREFIX + "/bootstrap/3.1.1/3.1.1/js/bootstrap.js", new WebJarVersionLocator().fullPath("bootstrap", "3.1.1/js/bootstrap.js"));
+    void full_path_exists_with_version_supplied() {
+        assertEquals(WebJarVersionLocator.WEBJARS_PATH_PREFIX + "/bootstrap/3.1.1/js/bootstrap.js", new WebJarVersionLocator().fullPath("bootstrap", "3.1.1/js/bootstrap.js"));
     }
 
     @Test
-    void path_double_version_with_version_supplied() {
-        assertEquals("bootstrap/3.1.1/3.1.1/js/bootstrap.js", new WebJarVersionLocator().path("bootstrap", "3.1.1/js/bootstrap.js"));
+    void path_exists_with_version_supplied() {
+        assertEquals("bootstrap/3.1.1/js/bootstrap.js", new WebJarVersionLocator().path("bootstrap", "3.1.1/js/bootstrap.js"));
     }
 
     @Test


### PR DESCRIPTION
This PR makes the behaviour of `path` and `fullPath` consistent. This is done by removing the version check, in `fullPath`. Also to not have the same `String.format` duplicated, i use the `path` method inside `fullPath`.

As this broke the related test, I updated the test and renamed the `full_path_exists_version_supplied` to `full_path_double_version_with_version_supplied` and added `path_double_version_with_version_supplied` to have a similar test for path only.

One thing to note here, is that this can and probably should be considered a minor breaking change. As this breaks cases where a user accidentally added a version to the referenced webjar resouce in thier html. Becaus of this I think maybe this should rather become a `1.1.0` instead of a `1.0.x` release. Not sure if this kind of breakage deserverse a major bump.

This also ensures that if Spring Boot upgrades to the version containing this does not silently land in `3.4.x` but only in `3.5.0` and thus can be mentioned in thier release notes.

Fixes https://github.com/webjars/webjars-locator-lite/issues/18