### PR TITLE
Add a module-name so this can ride on JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,13 @@
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.webjars.locator_lite</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This prevents the warning if used in project that do use module-info.java.
' Required filename-based automodules detected: [webjars-locator-lite-1.1.1.jar]. Please don't publish this project to a public artifact repository! *'